### PR TITLE
[FIX] account_analytic_wip: remove remaining column, as not relevant for WIP calculations

### DIFF
--- a/account_analytic_wip/models/account_analytic_tracking.py
+++ b/account_analytic_wip/models/account_analytic_tracking.py
@@ -96,6 +96,7 @@ class AnalyticTrackingItem(models.Model):
         store=True,
         help="Actual amount incurred above the planned amount limit.",
     )
+    # FIXME: remove as is not used
     remaining_actual_amount = fields.Float(
         compute="_compute_actual_amounts",
         store=True,

--- a/account_analytic_wip/views/account_analytic_tracking.xml
+++ b/account_analytic_wip/views/account_analytic_tracking.xml
@@ -26,7 +26,6 @@
                         <field name="planned_amount" string="Standard" />
                     </group>
                     <group string="Actuals" name="actuals">
-                        <field name="remaining_actual_amount" string="Remaining" />
                         <field name="actual_amount" string="Actuals" />
                         <field name="wip_actual_amount" string="WIP" />
                         <field name="difference_actual_amount" string="Difference" />
@@ -95,12 +94,6 @@
                     string="Standard"
                     optional="show"
                     sum="Standard"
-                />
-                <field
-                    name="remaining_actual_amount"
-                    string="Remaining"
-                    optional="show"
-                    sum="Remaining"
                 />
                 <field name="actual_amount" string="Actual" sum="Actual" />
                 <field


### PR DESCRIPTION
- [FIX] account_analytic_wip: remove remaining column, as not relevant for WIP calculations
